### PR TITLE
Modified db_querying so 'simple_builder' will be used by default.

### DIFF
--- a/patton_server/service/input_sources/__init__.py
+++ b/patton_server/service/input_sources/__init__.py
@@ -6,16 +6,13 @@ from .dpkg import dpkg_builder
 from .simple import simple_builder
 from .alpine import alpine_builder
 
+DEFAULT_BUILDER = simple_builder
+
 SOURCES = {
     # Ubuntu-like parsers
     'dpkg': dpkg_builder,
     'ubuntu': dpkg_builder,
     'debian': dpkg_builder,
-
-    # Default
-    'python': simple_builder,
-    'auto': simple_builder,
-    'simple': simple_builder,
 
     # Alpine-like
     'alpine': alpine_builder,
@@ -51,5 +48,6 @@ def specific_build_db_query(source: str,
         r = SOURCES[source](package, maximum_concurrent_packages_to_analyze)
         return r
     except KeyError:
-        raise PSException(f"Invalid source. "
-                          f"Valid sources are: {SOURCES.keys()}")
+        r = DEFAULT_BUILDER(package, maximum_concurrent_packages_to_analyze)
+    finally:
+        return r


### PR DESCRIPTION
Hello,

I was trying to write a parser for patton-cli but when trying it I get an error because the server doesn't expect that kind of source (I am trying to write a golang's Gopck.lock parser).

I changed the  `specific_build_db_query` function so if it receives an unexpected source type, it will try to use `simple_builder`